### PR TITLE
Refonte du système de variante des images

### DIFF
--- a/app/controllers/cdn_cgi/images_controller.rb
+++ b/app/controllers/cdn_cgi/images_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module CdnCgi
+  class ImagesController < ApplicationController
+    def variante_path
+      attachment = ActiveStorage::Attachment.joins(:blob).includes(:blob).find_by(active_storage_blobs: { key: params[:key] })
+      options = { 'quality': '90' }
+      params[:options].split(',').each do |option|
+        option = option.split('=')
+        options[option.first] = option.second
+      end
+
+      case options['fit']
+      when 'scale-down'
+        resize_attachement = attachment.variant(resize_to_limit: [options['width'].to_i, options['height'].to_i], quality: options['quality'].to_i).processed
+        redirect_to "#{ENV['OBLYK_API_URL']}#{Rails.application.routes.url_helpers.rails_representation_url(resize_attachement, only_path: true)}"
+
+      when 'crop'
+        size = "#{options['width']}x#{options['height']}"
+        resize_attachement = attachment.variant({ combine_options: { gravity: 'Center', resize: "#{size}^", crop: "#{size}+0+0", quality: options['quality'].to_i } }).processed
+        redirect_to "#{ENV['OBLYK_API_URL']}#{Rails.application.routes.url_helpers.rails_representation_url(resize_attachement, only_path: true)}"
+
+      else
+        redirect_to "#{ENV['OBLYK_API_URL']}#{Rails.application.routes.url_helpers.polymorphic_url(attachment, only_path: true)}"
+      end
+    end
+  end
+end

--- a/app/models/concerns/attachment_resizable.rb
+++ b/app/models/concerns/attachment_resizable.rb
@@ -3,6 +3,27 @@
 module AttachmentResizable
   extend ActiveSupport::Concern
 
+  def attachment_object(attachment)
+    variant_path = nil
+    attachment_attached = false
+    if attachment.attached?
+      storage_domaine = ENV.fetch('IMAGES_STORAGE_DOMAINE', ENV['OBLYK_API_URL'])
+      variant_path = "#{storage_domaine}/cdn-cgi/image/:variant/#{attachment.blob.key}"
+      attachment_attached = true
+    end
+    {
+      attached: attachment_attached,
+      attachment_type: "#{attachment.record.class.name}_#{attachment.name}",
+      variant_path: variant_path
+    }
+  rescue StandardError
+    {
+      attached: false,
+      attachment_type: "#{attachment&.record&.class&.name}_#{attachment&.name}",
+      variant_path: nil
+    }
+  end
+
   def resize_attachment(attachment, size)
     return unless attachment.attached?
 

--- a/app/models/gym_chain.rb
+++ b/app/models/gym_chain.rb
@@ -46,6 +46,10 @@ class GymChain < ApplicationRecord
         slug_name: slug_name,
         description: description,
         public_chain: public_chain,
+        attachments: {
+          banner: attachment_object(banner),
+          logo: attachment_object(logo)
+        },
         banner: banner.attached? ? banner_large_url : nil,
         banner_thumbnail_url: banner.attached? ? banner_thumbnail_url : nil,
         banner_cropped_url: banner ? banner_cropped_medium_url : nil,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :mirror_local_cloudflare
+  config.active_storage.service = ENV.fetch('ACTIVE_STORAGE_SERVICE', 'local')
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/local_env.example.yml
+++ b/config/local_env.example.yml
@@ -62,6 +62,12 @@ CLOUDFLARE_R2_SECRET_ACCESS_KEY: 'secret_access_key'
 CLOUDFLARE_R2_BUCKET: 'bucket'
 CLOUDFLARE_R2_DOMAIN: 'https://storage.exemple.com'
 
+# Images storage domaine
+IMAGES_STORAGE_DOMAINE: 'http://localhost:3000'
+
+# Type of storage service (used only on development environment)
+ACTIVE_STORAGE_SERVICE: 'local'
+
 # Mapbox
 MAPBOX_TOKEN: 'mapbox-token'
 MAPBOX_STATIC_MAP_STYLE: 'mapbox-style-for-static-image'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,11 @@ Rails.application.routes.draw do
 
   mount ActionCable.server => '/cable'
 
+  # equivalent of cloudflare "Transform via URL" for the development environment
+  # see : https://developers.cloudflare.com/images/transform-images/transform-via-url/
+  # only a few options are supported (fit=crop or fit=scale-down and quality)
+  get 'cdn-cgi/image/:options/:key', controller: 'cdn_cgi/images', action: :variante_path
+
   namespace :api do
     namespace :v1 do
       namespace :sessions do

--- a/http_client/http-client.env.json
+++ b/http_client/http-client.env.json
@@ -1,5 +1,6 @@
 {
   "development": {
-    "api_url": "http://localhost:3000/api/v1"
+    "api_url": "http://localhost:3000/api/v1",
+    "storage_url": "http://localhost:3000"
   }
 }


### PR DESCRIPTION
Refonte du système de variante d'image pour utiliser Transfrom via URL de Cloudflare

Mise en place d'une route similaire à https://developers.cloudflare.com/images/transform-images/transform-via-url/ pour ne pas perturber le développement local.

\+ ajout d'une variable d'environnement pour choisir son système de stockage dans son environnement de développement (par défaut : local, donc les fichiers sont stocké sur sa machine)

On met en place le nouveau système uniquement sur les groupes de salle pour faire un teste sur un petit panel

PR front : https://github.com/oblyk/oblyk-app/pull/128